### PR TITLE
GHC8 ready

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 dist
 .cabal*
 cabal.sandbox.config
+*.nix
+result
+*~

--- a/dalvik.cabal
+++ b/dalvik.cabal
@@ -19,8 +19,8 @@ Library
     Build-Depends:  base >= 4 && < 5,
                     containers,
                     deepseq >= 1.2 && < 1.5,
-                    attoparsec >= 0.10.0.0 && < 0.13,
-                    cereal >= 0.4 && < 0.5,
+                    attoparsec >= 0.10.0.0 && < 0.14,
+                    cereal >= 0.4 && < 0.6,
                     bytestring >= 0.9 && < 2,
                     text >= 0.11 && < 2,
                     zip-conduit >= 0.2 && < 0.3,
@@ -28,7 +28,7 @@ Library
                     exceptions >= 0.5 && < 0.9,
                     floatshow >= 0.2.4 && < 0.3,
                     data-binary-ieee754 >= 0.4.4 && < 0.5,
-                    IntervalMap >= 0.3.0.0 && < 0.5,
+                    IntervalMap >= 0.3.0.0 && < 0.6,
                     pretty,
                     GenericPretty >= 1.2 && < 1.3,
                     transformers >= 0.3 && < 0.6,
@@ -73,7 +73,7 @@ Library
                      Dalvik.SSA.Util
     -- The simpl-tick-factor flag is a workaround for ghc 7.8
     GHC-Options: -Wall -O1 -fsimpl-tick-factor=500000
-    GHC-Prof-Options: -prof -fprof-auto -fprof-cafs  -fsimpl-tick-factor=500000
+    GHC-Prof-Options: -fprof-auto -fprof-cafs  -fsimpl-tick-factor=500000
 
 Executable Dexdumper
   default-language: Haskell2010
@@ -85,7 +85,7 @@ Executable Dexdumper
   hs-source-dirs: tools/Dexdumper
   Main-Is: Main.hs
   GHC-Options: -Wall -O1
-  GHC-Prof-Options: -prof -fprof-auto -fprof-cafs -rtsopts -auto-all
+  GHC-Prof-Options: -fprof-auto -fprof-cafs -rtsopts -auto-all
 
 executable SSADumper
   default-language: Haskell2010
@@ -101,7 +101,7 @@ executable SSADumper
   main-is: Main.hs
   hs-source-dirs: tests/ssa, tools/SSADumper
   ghc-options: -Wall -O1 -rtsopts
-  ghc-prof-options: -prof -auto-all
+  ghc-prof-options: -auto-all
 
 test-suite ssa-tests
   default-language: Haskell2010
@@ -125,7 +125,7 @@ test-suite SSALabels
   type: exitcode-stdio-1.0
   main-is: SSALabels.hs
   ghc-options: -Wall -O1
-  ghc-prof-options: -prof -auto-all
+  ghc-prof-options: -auto-all
   hs-source-dirs: tests/ssa
   build-depends: base == 4.*,
                  containers,

--- a/src/Dalvik/AccessFlags.hs
+++ b/src/Dalvik/AccessFlags.hs
@@ -12,7 +12,6 @@ module Dalvik.AccessFlags
 
 import Data.Bits
 import Data.List
-import Data.Monoid
 import Data.String
 import Data.Word
 import Text.Printf

--- a/src/Dalvik/ClassName.hs
+++ b/src/Dalvik/ClassName.hs
@@ -12,7 +12,6 @@ module Dalvik.ClassName (
 import Control.Applicative
 import qualified Data.ByteString.Char8 as BS
 import Data.Hashable
-import Data.Monoid
 import qualified Data.Serialize as S
 
 import Prelude

--- a/src/Dalvik/SSA/Internal/BasicBlocks.hs
+++ b/src/Dalvik/SSA/Internal/BasicBlocks.hs
@@ -158,7 +158,7 @@ basicBlocksAsList = V.toList . bbBlocks
 
 type Handlers = IntervalMap Int ExceptionRange
 handlersFor :: Handlers -> Int -> [ExceptionRange]
-handlersFor h = map snd . IM.containing h
+handlersFor h = map snd . IM.toList . IM.containing h
 
 data BBEnv =
   BBEnv { envInstVec :: Vector Instruction
@@ -248,7 +248,7 @@ exceptionBlockTypes toInstIdx bnumMap =
       -- is dead code (no exceptions can actually reach it at
       -- runtime).
       let instIdx = toInstIdx (fromIntegral offset)
-      in case IM.containing bnumMap instIdx of
+      in case IM.toList $ IM.containing bnumMap instIdx of
         [(_, bnum)] -> M.insert bnum name m
         _ -> m
 
@@ -264,14 +264,14 @@ instructionEndsBlock bbs ix = IS.member ix $ bbBlockEnds bbs
 -- | Get the block number for an instruction
 instructionBlockNumber :: BasicBlocks -> Int -> Maybe BlockNumber
 instructionBlockNumber bbs ix =
-  case IM.containing (bbFromInstruction bbs) ix of
+  case IM.toList $ IM.containing (bbFromInstruction bbs) ix of
     [(_, bnum)] -> Just bnum
     _ -> Nothing
 
 -- | Get the basic block ID for the instruction at the given index.
 basicBlockForInstruction :: BasicBlocks -> Int -> BlockNumber
 basicBlockForInstruction bbs ix =
-  case IM.containing (bbFromInstruction bbs) ix of
+  case IM.toList $ IM.containing (bbFromInstruction bbs) ix of
     [(_, bnum)] -> bnum
     _ -> error ("No BasicBlock for Instruction at index " ++ show ix)
 
@@ -330,7 +330,7 @@ buildCFG env bvec bmap blockEnds =
       -- (so we can ignore it).  Otherwise, record CFG information and
       -- the branch targets.
       | Just targets <- terminatorAbsoluteTargets env ix inst
-      , [(_, termBlock)] <- IM.containing bmap ix =
+      , [(_, termBlock)] <-  IM.toList $ IM.containing bmap ix =
         let instIndexToBlockNum = second (blockForInstruction bmap)
             targetBlocks = map instIndexToBlockNum targets
             addSuccsPreds (p, s, b) (condition, targetBlock) =
@@ -342,7 +342,7 @@ buildCFG env bvec bmap blockEnds =
 
 blockForInstruction :: IntervalMap Int BlockNumber -> Int -> BlockNumber
 blockForInstruction m ix =
-  case IM.containing m ix of
+  case IM.toList $ IM.containing m ix of
     [(_, b)] -> b
     _ -> error ("No BasicBlock for instruction at index " ++ show ix)
 

--- a/src/Dalvik/Types.hs
+++ b/src/Dalvik/Types.hs
@@ -9,7 +9,6 @@ import Data.Int
 import qualified Data.List as L
 import Data.Map (Map)
 import Data.Maybe ( fromMaybe )
-import Data.Monoid
 import Data.String ( fromString )
 import Data.Typeable
 import Data.Word


### PR DESCRIPTION
Bumped versions, including `IntervalMap`, add `toList` before `containing`, to get it to typecheck. 
https://github.com/travitch/dalvik/compare/master...dmjio:master#diff-0ca04c04856f642ad31acefc82ecb37eR161

I believe this change is correct since it seems `IntervalMap` added `fromAscList` to the `containing` function, changing it's return type from a list to an `IntervalMap`. The implementation remains the same otherwise. 
 
## Version 0.4
```haskell
containing :: (Interval k e) => IntervalMap k v -> e -> [(k, v)]
t `containing` pt = go [] pt t
  where
    go xs p Nil = p `seq` xs
    go xs p (Node _ k m v l r)
       | p `above` m  =  xs         -- above all intervals in the tree: no result
       | p `below` k  =  go xs p l  -- to the left of the lower bound: can't be in right subtree
       | p `inside` k =  go ((k,v) : go xs p r) p l
       | otherwise    =  go (go xs p r) p l
```

## Version 0.5
```haskell
containing :: (Interval k e) => IntervalMap k v -> e -> IntervalMap k v
t `containing` pt = pt `seq` fromDistinctAscList (go [] pt t) -- `fromDistinctAscList`
  where
    go xs _ Nil = xs
    go xs p (Node _ k m v l r)
       | p `above` m  =  xs         -- above all intervals in the tree: no result
       | p `below` k  =  go xs p l  -- to the left of the lower bound: can't be in right subtree
       | p `inside` k =  go ((k,v) : go xs p r) p l
       | otherwise    =  go (go xs p r) p l
```
### `toList` is `toAscList`
```haskell
toList :: IntervalMap k v -> [(k,v)]
toList m = toAscList m
```

# **Warning**
I didn't test it, whenever I try, I get this error:
```bash
[1 of 1] Compiling Main             ( tests/roundtrip/Main.hs, dist/build/roundtrip/roundtrip-tmp/Main.dyn_o )
Linking dist/build/roundtrip/roundtrip ...
running tests
Running 3 test suites...
Test suite ssa-tests: RUNNING...
SSA Tests:
  ThreeIncomingValues: [Failed]
ERROR: dx: runProcess: runInteractiveProcess: exec: does not exist (No such file or directory)
  TwoPhis: [Failed]
ERROR: dx: runProcess: runInteractiveProcess: exec: does not exist (No such file or directory)
  OneUnusedPhi: [Failed]
ERROR: dx: runProcess: runInteractiveProcess: exec: does not exist (No such file or directory)
  Trivial: [Failed]
ERROR: dx: runProcess: runInteractiveProcess: exec: does not exist (No such file or directory)
  EnsureExceptionBlock: [Failed]
ERROR: dx: runProcess: runInteractiveProcess: exec: does not exist (No such file or directory)
  SimpleLoop: [Failed]
ERROR: dx: runProcess: runInteractiveProcess: exec: does not exist (No such file or directory)
  ConditionalStringsReturned: [Failed]
ERROR: dx: runProcess: runInteractiveProcess: exec: does not exist (No such file or directory)
  NestedLoop: [Failed]
ERROR: dx: runProcess: runInteractiveProcess: exec: does not exist (No such file or directory)
  ConditionalStringsAssigned: [Failed]
ERROR: dx: runProcess: runInteractiveProcess: exec: does not exist (No such file or directory)
  ConditionalInts: [Failed]
ERROR: dx: runProcess: runInteractiveProcess: exec: does not exist (No such file or directory)
  EliminateUnreachableCatch: [Failed]
ERROR: dx: runProcess: runInteractiveProcess: exec: does not exist (No such file or directory)

         Test Cases   Total       
 Passed  0            0           
 Failed  11           11          
 Total   11           11          
Test suite ssa-tests: FAIL
Test suite logged to: dist/test/dalvik-0.4.1.1-ssa-tests.log
Test suite SSALabels: RUNNING...
^Ckilling process 24038
error: interrupted by the user
```

Is `dx` an android thing?